### PR TITLE
fix bug - 模拟接口无法使用

### DIFF
--- a/src/routes/utils/url.ts
+++ b/src/routes/utils/url.ts
@@ -26,7 +26,7 @@ export default class UrlUtils {
     url = UrlUtils.getRelative(url)
     pattern = UrlUtils.getRelative(pattern)
     let re = pathToRegexp(pattern)
-    return re.test(url)
+    return re.test(pattern)
   }
 
 }


### PR DESCRIPTION
`url`是以methods开头，而`pattern`不含methods，所以`pathToRegexp(pattern)`产生的正则永远无法匹配到`url`。

---

结果是模拟的接口都无法访问。