### PR TITLE
修复restful模式下，没有考虑请求的HTTP Method，导致提示“匹配到多个接口…”

### DIFF
--- a/src/routes/mock.ts
+++ b/src/routes/mock.ts
@@ -170,6 +170,7 @@ router.all('/app/mock/:repositoryId(\\d+)/:url(.+)', async (ctx) => {
       attributes: ['id', 'url', 'method'],
       where: {
         repositoryId: [repositoryId, ...collaborators.map(item => item.id)],
+        method
       },
     })
 


### PR DESCRIPTION
定义两个rest接口，一个GET 一个POST，URI相同；如下：
![image](https://user-images.githubusercontent.com/11937688/45341268-973b4580-b5cc-11e8-8609-8cbc5240247d.png)

postman请求提示“匹配到多个接口”
![image](https://user-images.githubusercontent.com/11937688/45341316-c81b7a80-b5cc-11e8-8e4e-fb3913b1ab47.png)

加上method后工作正常
![image](https://user-images.githubusercontent.com/11937688/45341459-50018480-b5cd-11e8-96a1-b0da813b194f.png)
