### PR TITLE
使用npm run create-db初始化数据库表生成的数据库明文密码无法登录

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ npm run build
 npm run create-db
 ```
 
+#### 连接数据库，修改RAP2管理员账号密码
+```
+update users set password = md5('admin') where fullname = 'admin';
+```
+
 #### 执行mocha测试用例和js代码规范检查
 ```bash
 npm run check

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -155,7 +155,7 @@ router.post('/account/update', async (ctx) => {
     errMsg = '密码长度过短'
   } else {
     const user = await User.findById(ctx.session.id)
-    user.password = md5(md5(password))
+    user.password = md5(password)
     await user.save()
     isOk = true
   }


### PR DESCRIPTION
添加文档说明如何修改RAP2管理员密码，数据库保存密码为一次md5加密值，并修改登录验证多余一层md5函数bug