### PR TITLE
docker-compose中的配置过时

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     # build from ./Dockerfile
 #    build: .
     # build from images
-    image: blackdog1987/rap2-delos:1.0.0
+    # you can find last tag from https://hub.docker.com/r/blackdog1987/rap2-delos
+    image: blackdog1987/rap2-delos:2.6.aa3be03
     environment:
       # if you have your own mysql, config it here, and disable the 'mysql' config blow
       - MYSQL_URL=rap2-mysql # links will maintain /etc/hosts, just use 'container_name'


### PR DESCRIPTION
docker-compose.yml中`delos`使用的image版本还是`1.0.0`，与 [rap2-dolores](https://github.com/thx/rap2-dolores) 中的`master`版本没有对齐，导致使用[rap2-dolores](https://github.com/thx/rap2-dolores)新版本的时候页面报错。
现已调整为 https://hub.docker.com/r/blackdog1987/rap2-delos 中的最新版本