### PR TITLE
调整地址匹配规则

### DIFF
--- a/src/routes/utils/url.ts
+++ b/src/routes/utils/url.ts
@@ -29,5 +29,9 @@ export default class UrlUtils {
     let re = pathToRegexp(pattern)
     return re.test(url)
   }
+  public static getUrlPattern = (pattern: string) => {
+    pattern = UrlUtils.getRelative(pattern);
+    return pathToRegexp(pattern);
+  }
 
 }


### PR DESCRIPTION
#### 调整原因
> 由于业务原因，地址会出现： `[GET]/api/resource/:id` 和  `[GET]/api/resource/operator`
> 当请求`/api/resource/operator` 时，两个地址均会匹配，则会抛出`匹配到多个接口，请修改规则确保接口规则唯一性。 Matched multiple interfaces, please ensure pattern to be unique.`错误。
> 经过调整后，请求`/api/resource/operator`，匹配`/api/resource/operator`，
>请求`/api/resource/other`，匹配`/api/resource/:id`

#### 提交文件注释
1.添加url正则对象获取方法
2.调整地址匹配多个时逻辑处理为：
> 优先使用地址中动态数据较少的地址
> 出现动态数据数量相同时，抛出异常