### PR TITLE
修改rap2-delos初始化mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,12 @@ services:
     privileged: true
     ###### 'sleep 30 && node scripts/init' will drop the tables
     ###### RUN ONLY ONCE THEN REMOVE 'sleep 30 && node scripts/init'
-    command: /bin/sh -c 'sleep 30; node scripts/init; node dispatch.js'
+    
+    ##choose for command: without init (default)
     # init the databases
 #    command: sleep 30 && node scripts/init && node dispatch.js
     # without init
-#    command: node dispatch.js
+    command: node dispatch.js
     links:
       - redis
       - mysql


### PR DESCRIPTION
明明有两种情况需要运行的命令，要哪个取消哪个的注释就好了。默认初始化database，不是很友好，每次服务器重启，rap2的数据就丢失了。