### PR TITLE
fix: swagger 导入路由处理错误

### DIFF
--- a/src/service/migrate.ts
+++ b/src/service/migrate.ts
@@ -671,7 +671,7 @@ export default class MigrateService {
       }
     }
 
-    let { tags = [], paths = {}, host = '' } = swagger
+    let { tags = [], paths = {} } = swagger
     let pathTag: SwaggerTag[] = []
 
     // 获取所有的TAG: 处理ROOT TAG中没有的情况
@@ -783,7 +783,7 @@ export default class MigrateService {
               moduleId: mod.id,
               name: `${apiObj.summary}`,
               description: apiObj.description,
-              url: `https//${host}${url.replace('-test', '')}`,
+              url: `${url.replace('-test', '')}`,
               priority: iCounter++,
               creatorId: curUserId,
               repositoryId: repositoryId,
@@ -806,7 +806,7 @@ export default class MigrateService {
                 moduleId: mod.id,
                 name: `${apiObj.summary}`,
                 description: apiObj.description,
-                url: `https//${host}${url.replace('-test', '')}`,
+                url: `${url.replace('-test', '')}`,
                 repositoryId: repositoryId,
                 method: method.toUpperCase(),
               },


### PR DESCRIPTION
在 rap2 中使用路由的方式为 /api/list/xxxx。 配合 Rapper prefix处理。或者用户前端自己处理域名前缀。导入 swagger 时不应该处理添加 协议以及 host 前缀处理