### PR TITLE
修复 swagger json 中 definitions 不存在时导入报错问题

### DIFF
--- a/src/service/migrate.ts
+++ b/src/service/migrate.ts
@@ -508,7 +508,7 @@ export default class MigrateService {
     method: string,
     apiInfo: any,
   ): Promise<any> {
-    let { definitions } = swagger
+    let { definitions = {} } = swagger
     const result = []
     definitions = JSON.parse(JSON.stringify(definitions)) // 防止接口之间数据处理相互影响
 


### PR DESCRIPTION
Fix #711 