### PR TITLE
fix: swagger导入失败问题

### DIFF
--- a/src/service/migrate.ts
+++ b/src/service/migrate.ts
@@ -517,7 +517,7 @@ export default class MigrateService {
     const result = []
     definitions = JSON.parse(JSON.stringify(definitions)) // 防止接口之间数据处理相互影响
 
-    if (method === 'get' || method === 'GET') {
+    if (Array.isArray(parameters) && method === 'get' || method === 'GET') {
       parse(
         parameters.filter(item => item.in !== 'body') || [],
         'root',


### PR DESCRIPTION
导入swagger时，如果导入的接口文档没有参数（parameters），会报错，从而返回给前端导入失败。