### PR TITLE
数据库无法连接上

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,5 +61,6 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
       MYSQL_DATABASE: "rap2"
-      MYSQL_USER: "root"
+  #   新版docker可能需要注释掉这个选项，否则无法启动 见 https://stackoverflow.com/questions/66831863/mysql-docker-container-keeps-restarting
+  #    MYSQL_USER: "root"
       MYSQL_PASSWORD: ""


### PR DESCRIPTION
错误如下：
[Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user

Remove MYSQL_USER="root" and use one of the following to control the root user password:

- MYSQL_ROOT_PASSWORD

- MYSQL_ALLOW_EMPTY_PASSWORD

- MYSQL_RANDOM_ROOT_PASSWORD

解决办法见：
https://stackoverflow.com/questions/66831863/mysql-docker-container-keeps-restarting